### PR TITLE
Fix upstream source URL and upgrade to latest version

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,10 +5,10 @@
 APPNAME="ttrss"
 
 # ttrss version, use latest commit found here: https://tt-rss.org/fox/tt-rss/commits/master
-VERSION="6fd03996"
+VERSION="17.4"
 
 # Remote URL to fetch ttrss tarball
-TTRSS_BINARY_URL="https://tt-rss.org/fox/tt-rss/repository/archive.zip?ref=${VERSION}"
+TTRSS_BINARY_URL="https://git.tt-rss.org/git/tt-rss/archive/${VERSION}.tar.gz"
 
 #
 # Common helpers

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,7 +8,7 @@ APPNAME="ttrss"
 VERSION="17.4"
 
 # Remote URL to fetch ttrss tarball
-TTRSS_BINARY_URL="https://git.tt-rss.org/git/tt-rss/archive/${VERSION}.tar.gz"
+TTRSS_BINARY_URL="https://git.tt-rss.org/git/tt-rss/archive/${VERSION}.zip"
 
 #
 # Common helpers

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 APPNAME="ttrss"
 
 # ttrss version, use latest commit found here: https://tt-rss.org/fox/tt-rss/commits/master
-VERSION="17.4"
+VERSION="09628e1b1a"
 
 # Remote URL to fetch ttrss tarball
 TTRSS_BINARY_URL="https://git.tt-rss.org/git/tt-rss/archive/${VERSION}.zip"


### PR DESCRIPTION
Patch to fix upstream archive URL (the site has moved).
Change the referenced version to the latest commit.

- [X] Complete test : JimboJoe
- [X] Upgrade previous version : JimboJoe
- [X] Code review : JimboJoe
- [x] Approval (LGTM)
- [X] Approval (LGTM) frju365
- [x] CI succeeded : JimboJoe

[Minor decision](https://github.com/YunoHost/project-organization/blob/master/yunohost_project_organization.md#minor-decision), closed on June 21st, or June 17th if anticipated.