### PR TITLE
Remove 20-.ini from backup and restore

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -50,7 +50,6 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
-ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # BACKUP THE MYSQL DATABASE

--- a/scripts/restore
+++ b/scripts/restore
@@ -83,7 +83,6 @@ chown -R $app $final_path/{cache,feed-icons,lock}
 #=================================================
 
 ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
-ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # SPECIFIC RESTORATION


### PR DESCRIPTION
## Problem
- *Backup failed with "Source path '/etc/php5/fpm/conf.d/20-ttrss.ini' does not exist"*

## Solution
- *Remove `/etc/php5/fpm/conf.d/20-$app.ini` from backup and restore.
This file is not used in this script.*

## PR Status
Work finished. Package_check, basic tests and upgrade from last version OK.  
Could be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Upgrade previous version** : Not relevant.
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : frju365
- [x] **CI succeeded** : [![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20fix_backup_restore%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20fix_backup_restore%20(Official)/)  
When the PR is mark as ready to merge, you have to wait for 3 days before really merge it.