### PR TITLE
[fix] don’t remove cron job on upgrade if not/no more present

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -6,7 +6,6 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -49,7 +48,9 @@ ynh_abort_if_errors	# Active trap pour arrêter le script si une erreur est dét
 #=================================================
 
 # Remove old cron job
-ynh_secure_remove "/etc/cron.d/$app"
+if [ -e "/etc/cron.d/$app" ]; then
+    ynh_secure_remove "/etc/cron.d/$app"
+fi
 
 #=================================================
 # CHECK THE PATH


### PR DESCRIPTION
Trying to upgrade ttrss twice in a row doesn’t work and will block future upgrades as well (see https://github.com/YunoHost-Apps/ttrss_ynh/issues/46#issuecomment-354243666).

With this PR, the upgrade script delete the old cron file only if found on the filesystem.