### PR TITLE
Configure systemd to auto-restart the service

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -6,6 +6,8 @@ After=network.target mysql.service
 User=__APP__
 Group=__APP__
 ExecStart=/usr/bin/php __FINALPATH__/update_daemon2.php
+Restart=always
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Problem
- *The systemd service seems to sometimes stop for people (it happened to myself as well) and there's no way to know that, except that our feeds stay desperately empty...*

## Solution
- *Configure systemd so that the service gets automatically restarted whatever the reason it gets stopped*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Josué
- [x] **Approval (LGTM)** : Maniack C
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20enh_auto_restart%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20enh_auto_restart%20(Official)/)

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
