### PR TITLE
Fix remote login user

### DIFF
--- a/sources/patches/app-login_remote_user.patch
+++ b/sources/patches/app-login_remote_user.patch
@@ -1,0 +1,21 @@
+--- /include/functions.php
++++ /include/functions.php
+@@ -825,6 +825,18 @@
+ 				}
+ 
+ 			} else {
++				/* We need to check that the "REMOTE_USER" and "uid" are same.
++				 * If it has changed it's probably that the user logged out and
++				 * was authenticated with a other username.
++				 * In this case we need to reauthenticate the user
++				 */
++				if (AUTH_AUTO_LOGIN && $_SERVER["REMOTE_USER"] != $_SESSION["uid"]) {
++					if (authenticate_user(null, null)) {
++						$_SESSION["ref_schema_version"] = get_schema_version(true);
++					} else {
++						authenticate_user(null, null, true);
++					}
++				}
+ 				/* bump login timestamp */
+ 				$sth = $pdo->prepare("UPDATE ttrss_users SET last_login = NOW() WHERE id = ?");
+ 				$sth->execute([$_SESSION['uid']]);


### PR DESCRIPTION
## Problem
- When the authenticated user change, TTRSS keep the old user by the cookies


## Solution
- Force TTRSS to reload the the "REMOTE_USER" if it change

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20fix_remote_login_user%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20fix_remote_login_user%20(Official)/)

When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
