### PR TITLE
/var/www owned by ttrss user/group

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -124,8 +124,7 @@ ynh_add_systemd_config
 #=================================================
 
 # Set permissions to app files
-chown -R root: $final_path
-chown -R $app $final_path/{cache,feed-icons,lock}
+chown -R $app:$app $final_path
 
 #=================================================
 # INITIALIZE DATABASE


### PR DESCRIPTION
### because :
- the [user is created](https://github.com/YunoHost-Apps/ttrss_ynh/blob/master/scripts/install#L90-L91) 
- the user is used by the fpm-pool as I see in `/etc/php/7.0/fpm/pool.d/ttrss.conf`
and if I `chown -R ttrss:ttrss /var/www`
tt-rss still working well
