### PR TITLE
Fix upgrade (don't keep deleted files from older upstream versions)

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -14,3 +14,29 @@ ynh_delete_file_checksum () {
 	local checksum_setting_name=checksum_${1//[\/ ]/_}	# Replace all '/' and ' ' by '_'
 	ynh_app_setting_delete $app $checksum_setting_name
 }
+
+ynh_smart_mktemp () {
+        local min_size="${1:-300}"
+        # Transform the minimum size from megabytes to kilobytes
+        min_size=$(( $min_size * 1024 ))
+
+        # Check if there's enough free space in a directory
+        is_there_enough_space () {
+                local free_space=$(df --output=avail "$1" | sed 1d)
+                test $free_space -ge $min_size
+        }
+
+        if is_there_enough_space /tmp; then
+                local tmpdir=/tmp
+        elif is_there_enough_space /var; then
+                local tmpdir=/var
+        elif is_there_enough_space /; then
+                local tmpdir=/
+        elif is_there_enough_space /home; then
+                local tmpdir=/home
+        else
+		ynh_die "Insufficient free space to continue..."
+        fi
+
+        echo "$(sudo mktemp --directory --tmpdir="$tmpdir")"
+}

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -40,6 +40,10 @@ fi
 
 ynh_backup_before_upgrade	# Backup the current version of the app
 ynh_clean_setup () {
+	# Delete any created temporary folder
+	if [ -v tmpdir ] && [ -d $tmpdir ]; then
+		ynh_secure_remove $tmpdir
+	fi
 	ynh_restore_upgradebackup	# restore it if the upgrade fails
 }
 ynh_abort_if_errors	# Active trap pour arrêter le script si une erreur est détectée.

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -6,7 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
-# source _common.sh
+source _common.sh
 source /usr/share/yunohost/helpers
 
 #=================================================
@@ -64,8 +64,11 @@ path_url=$(ynh_normalize_url_path $path_url)
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 
+# Create a temporary directory
+tmpdir="$(ynh_smart_mktemp 10)"
+
 # Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source "$final_path"
+ynh_setup_source "$tmpdir"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -99,6 +102,14 @@ ynh_add_fpm_config
 # CONFIGURE TTRSS
 #=================================================
 
+# Backup the config file in the temp dir
+cp -a "$final_path/config.php" "$tmpdir/config.php"
+
+# Replace the old ttrss by the new one
+ynh_secure_remove "$final_path"
+mv "$tmpdir" "$final_path"
+ynh_secure_remove "$tmpdir"
+
 # Verify the checksum and backup the file if it's different
 ynh_backup_if_checksum_is_different "$final_path/config.php"
 
@@ -126,6 +137,7 @@ sudo -u $app php ${final_path}/update.php --update-schema
 
 # Set permissions to app files
 chown -R root: $final_path
+chmod 0755 $final_path
 chown -R $app $final_path/{cache,feed-icons,lock}
 
 #=================================================


### PR DESCRIPTION
## Problem
- *Upgrade to 19.2 introduced UI problems due to remaining files from previous upstream version*

## Solution
- *Keep only configuration file when upgrading*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- **Upgrade previous version** : 
- [x] **Code review** : Maniack C
- [x] **Approval (LGTM)** : Maniack C
- [x] **Approval (LGTM)** : Kay0u
- **CI succeeded** : 
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20fix_upgrade%20(Official)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/ttrss_ynh%20fix_upgrade%20(Official)/)
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.
